### PR TITLE
[#11]FEAT: historical data download endpoint

### DIFF
--- a/apis/alpaca.py
+++ b/apis/alpaca.py
@@ -16,12 +16,13 @@ headers = {
   'APCA-API-SECRET-KEY': os.getenv('ALPACA_PAPER_KEY_SECRET'),
 }
 
-def get_historical_bars(symbols: list[str], weeks: int = 2) -> dict:
+def get_recent_bars(symbols: list[str], weeks: int = 2) -> dict:
   '''
+  매도/매수 판단을 위한 최신 데이터 요청
   Alpaca API 를 통해 stock 가격 기록을 받고, 공통 형태로 변환하여 출력
 
-  Getting historical stock prices, and
-  Return a dictionary of historical data with keys of symbols
+  Getting recent stock prices, and
+  Return a dictionary of recent data with keys of symbols
   '''
   dataList = {}
   nextPageToken = None
@@ -69,6 +70,58 @@ def get_historical_bars(symbols: list[str], weeks: int = 2) -> dict:
 
     raise CustomError(
       status_code=500,
-      message="Internal server error",
-      detail="receiving and processing data from Alpaca API"
+      message='Internal server error',
+      detail='receiving and processing data from Alpaca API'
+    )
+
+def get_historical_bars(symbol, timeframe, startDate, endDate):
+  '''
+  성능 평가를 위한 장기 데이터 요청
+  Alpaca API 를 통해 stock 가격 기록을 받고, 공통 형태로 변환하여 출력
+
+  Getting historical stock prices, and
+  Return a list of historical data of a symbol
+  '''
+  dataList = []
+  nextPageToken = None
+
+  try:
+    params = {
+      'timeframe': timeframe,
+      'start': startDate,
+      'end': min(endDate, (datetime.utcnow() - timedelta(minutes=16)).isoformat(timespec='milliseconds') + 'Z'),
+      'limit': 1000,
+      'adjustment': 'raw',
+    }
+
+    while True:
+      if nextPageToken:
+        params['page_token'] = nextPageToken
+
+      response = requests.get(
+        url=baseurl + f'/stocks/{symbol}/bars',
+        headers=headers,
+        params=params,
+      )
+
+      assert response.status_code == 200, response.message
+
+      response = response.json()
+
+      dataList = [*dataList, *response['bars']]
+
+      if response['next_page_token']:
+        nextPageToken = response['next_page_token']
+      else:
+        break
+
+    return dataList
+
+  except:
+    print(traceback.format_exc())
+
+    raise CustomError(
+      status_code=500,
+      message='Internal server error',
+      detail='receiving and processing data from Alpaca API'
     )

--- a/apps/dataarchiving.py
+++ b/apps/dataarchiving.py
@@ -2,10 +2,17 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi import Body
 
-from scripts.archiving import real_time_archiving
+from scripts.archiving import real_time_archiving, historical_archiving
 from apps.error import CustomError
 
 dataArchiving = FastAPI()
+
+@dataArchiving.exception_handler(CustomError)
+def custom_error_handler(request: Request, exc: CustomError):
+    return JSONResponse(
+        content={"message": f'{exc.message} in {exc.detail}'},
+        status_code=exc.status_code
+    )
 
 @dataArchiving.get('/')
 def hello_data_archiving():
@@ -36,9 +43,16 @@ def real_time(symbols: list = Body(embed=True)):
     status_code=201,
   )
 
-@dataArchiving.exception_handler(CustomError)
-def custom_error_handler(request: Request, exc: CustomError):
-    return JSONResponse(
-        content={"message": f'{exc.message} in {exc.detail}'},
-        status_code=exc.status_code
-    )
+@dataArchiving.post('/historical')
+def historical(data: dict):
+   symbol = data.get('symbol')
+   timeframe = data.get('timeframe')
+   startDate = data.get('startDate')
+   endDate = data.get('endDate')
+
+   historical_archiving(symbol, timeframe, startDate, endDate)
+
+   return JSONResponse(
+      content={"message": "success"},
+      status_code=201,
+   )


### PR DESCRIPTION
## [#11] FEAT : 백테스트 용 장기 데이터 요청 엔드포인트 작성

## 세부 내용

- 특정 종목, 시작일, 종료일, 시간 간격을 옵션으로 받아서 API 호출
- 전달된 데이터를 csv 형태로 저장

## 이슈 번호
- Resolved: #11 
